### PR TITLE
Use maven wagon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ target/
 pom.xml.bak
 build.log
 interpolated-pom.xml
+interpolated-settings.xml

--- a/README.md
+++ b/README.md
@@ -14,9 +14,15 @@ if the just built artifact is already in the remote repository.
 |project    |${project.groupId}:${project.artifactId}:${project.version}| The project within the repository to query|
 |artifact   |${project.artifactId}-${project.version}.pom|The artifact within the project to query|
 |property   |maven.deploy.skip|The property to receive the result of the query|
-|uuseChecksum|${createChecksum}|Use checksum to compare artifacts (Checksums only available when install plugin is so configured.)|
+|userProperty|false|If the property should be set as a user property, to be available in child projects|
+|useChecksum|${createChecksum}|Use checksum to compare artifacts (Checksums only available when install plugin is so configured.)|
 |skipIfSnapshot|true|If checksums are not used, skip the query if the project ends with -SNAPSHOT|
 |repository |${project.distributionManagement.repository.url}| For remote goal, the repository to query for artifacts|
+|snapshotRepository |${project.distributionManagement.snapshotRepository.url}| For remote goal, the repository to query for snapshot artifacts|
+|serverId|${project.distributionManagement.repository.id}|For remote goal, the server ID to use for authentication and proxy settings|
+|snapshotServerId|${project.distributionManagement.snapshotRepository.id}|For remote goal, the server ID to use for snapshot authentication and proxy settings|
+|failIfExists|${failIfExists}|Fail the build if the artifact already exists|
+|failIfNotExists|${failIfNotExists}|Fail the build if the artifact does not exist|
 
 Typical use:
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,6 @@
   </properties>
 
   <dependencies>
-
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
@@ -89,6 +88,12 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.2.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.codehaus.mojo</groupId>
+      <artifactId>wagon-maven-plugin</artifactId>
+      <version>1.0</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,10 @@
       <email>chas@honton.org</email>
       <url>https://www.linkedin.com/in/chonton</url>
     </developer>
+    <developer>
+      <name>Pascal</name>
+      <url>https://github.com/pascalgn</url>
+    </developer>
   </developers>
 
   <scm>
@@ -74,6 +78,18 @@
 
     <dependency>
       <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact-manager</artifactId>
+      <version>2.2.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>3.3.9</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
       <version>3.0</version>
     </dependency>
@@ -86,14 +102,8 @@
 
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
-      <version>2.2.1</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.codehaus.mojo</groupId>
-      <artifactId>wagon-maven-plugin</artifactId>
-      <version>1.0</version>
+      <artifactId>maven-settings</artifactId>
+      <version>3.3.9</version>
     </dependency>
 
     <dependency>
@@ -104,9 +114,15 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.maven.wagon</groupId>
+      <artifactId>wagon-provider-api</artifactId>
+      <version>2.10</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>1.5.15</version>
+      <version>3.0.24</version>
     </dependency>
   </dependencies>
 
@@ -123,25 +139,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-install-plugin</artifactId>
         <version>2.4</version>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <configuration>
-              <portNames>
-                <portName>deploy.webserver.port</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>
@@ -189,6 +186,25 @@
           <execution>
             <id>default-descriptor</id>
             <phase>process-classes</phase>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>reserve-network-port</id>
+            <goals>
+              <goal>reserve-network-port</goal>
+            </goals>
+            <configuration>
+              <portNames>
+                <portName>deploy.webserver.port</portName>
+              </portNames>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.honton.chas</groupId>
   <artifactId>exists-maven-plugin</artifactId>
-  <version>0.0.2</version>
+  <version>0.0.3-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>Artifact Exists Maven Plugin</name>
@@ -148,6 +148,7 @@
         <artifactId>maven-invoker-plugin</artifactId>
         <version>2.0.0</version>
         <configuration>
+          <preBuildHookScript>clean</preBuildHookScript>
           <postBuildHookScript>verify</postBuildHookScript>
           <addTestClassPath>true</addTestClassPath>
           <settingsFile>src/it/settings.xml</settingsFile>

--- a/src/it/deploy/pom.xml
+++ b/src/it/deploy/pom.xml
@@ -10,16 +10,20 @@
   </parent>
   <artifactId>exists-deploy-it</artifactId>
 
+  <properties>
+    <deploy.webserver.port>@deploy.webserver.port@</deploy.webserver.port>
+  </properties>
+
   <distributionManagement>
 
     <repository>
       <id>test</id>
-      <url>http://localhost:@deploy.webserver.port@/repo</url>
+      <url>http://localhost:${deploy.webserver.port}/repo</url>
     </repository>
 
     <snapshotRepository>
       <id>test</id>
-      <url>http://localhost:@deploy.webserver.port@/repo</url>
+      <url>http://localhost:${deploy.webserver.port}/repo</url>
     </snapshotRepository>
 
   </distributionManagement>
@@ -111,7 +115,7 @@
                 <argument>-classpath</argument>
                 <argument>${runtime.classpath}${path.separator}${project.build.outputDirectory}</argument>
                 <argument>org.honton.chas.exists.example.WebServer</argument>
-                <argument>@deploy.webserver.port@</argument>
+                <argument>${deploy.webserver.port}</argument>
               </arguments>
             </configuration>
           </execution>

--- a/src/it/deploy/pom.xml
+++ b/src/it/deploy/pom.xml
@@ -90,11 +90,33 @@
             <phase>integration-test</phase>
           </execution>
           <execution>
+            <id>after-installation-with-auth</id>
+            <goals>
+              <goal>remote</goal>
+            </goals>
+            <phase>integration-test</phase>
+            <configuration>
+              <repository>http://localhost:${deploy.webserver.port}/auth/repo</repository>
+              <serverId>with-auth</serverId>
+            </configuration>
+          </execution>
+          <execution>
             <id>before-installation</id>
             <goals>
               <goal>remote</goal>
             </goals>
             <phase>test</phase>
+          </execution>
+          <execution>
+            <id>before-installation-with-auth</id>
+            <goals>
+              <goal>remote</goal>
+            </goals>
+            <phase>test</phase>
+            <configuration>
+              <repository>http://localhost:${deploy.webserver.port}/auth/repo</repository>
+              <serverId>with-auth</serverId>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/src/it/deploy/verify.bsh
+++ b/src/it/deploy/verify.bsh
@@ -20,7 +20,11 @@ import java.nio.file.Files;
 
   findLine(reader, "\\[INFO\\] --- exists-maven-plugin:[0-9\\.]*:remote \\(before-installation\\) @ exists-deploy-it ---");
   findLine(reader, "\\[INFO\\] setting maven.deploy.skip=false");
+  findLine(reader, "\\[INFO\\] --- exists-maven-plugin:[0-9\\.]*:remote \\(before-installation-with-auth\\) @ exists-deploy-it ---");
+  findLine(reader, "\\[INFO\\] setting maven.deploy.skip=false");
   findLine(reader, "\\[INFO\\] --- exists-maven-plugin:[0-9\\.]*:remote \\(after-installation\\) @ exists-deploy-it ---");
+  findLine(reader, "\\[INFO\\] setting maven.deploy.skip=true");
+  findLine(reader, "\\[INFO\\] --- exists-maven-plugin:[0-9\\.]*:remote \\(after-installation-with-auth\\) @ exists-deploy-it ---");
   findLine(reader, "\\[INFO\\] setting maven.deploy.skip=true");
 
 

--- a/src/it/fail/clean.bsh
+++ b/src/it/fail/clean.bsh
@@ -1,0 +1,17 @@
+import java.io.File;
+import java.io.FileFilter;
+
+FileFilter fileFilter = new FileFilter() {
+  public boolean accept(File file) {
+    if (file.isDirectory()) {
+      file.listFiles(fileFilter);
+    }
+    file.delete();
+    return false;
+  }
+};
+
+File file = new File(localRepositoryPath, "org/honton/chas");
+file.listFiles(fileFilter);
+
+return null;

--- a/src/it/fail/invoker.properties
+++ b/src/it/fail/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals = clean verify
+invoker.failureBehavior = fail-at-end
+invoker.buildResult = failure

--- a/src/it/fail/pom.xml
+++ b/src/it/fail/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.honton.chas</groupId>
+    <artifactId>exists-it-parent</artifactId>
+    <version>0.0.2</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>exists-fail-it</artifactId>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <executions>
+          <!-- install in earlier than usual phase -->
+          <execution>
+            <goals>
+              <goal>install</goal>
+            </goals>
+            <phase>integration-test</phase>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.honton.chas</groupId>
+        <artifactId>exists-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>after-installation</id>
+            <goals>
+              <goal>local</goal>
+            </goals>
+            <configuration>
+              <failIfExists>true</failIfExists>
+            </configuration>
+            <!-- default phase is verify -->
+          </execution>
+          <execution>
+            <id>before-installation</id>
+            <goals>
+              <goal>local</goal>
+            </goals>
+            <phase>pre-integration-test</phase>
+            <configuration>
+              <failIfExists>true</failIfExists>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+
+  </build>
+
+</project>

--- a/src/it/fail/src/main/java/org/honton/chas/exists/example/Main.java
+++ b/src/it/fail/src/main/java/org/honton/chas/exists/example/Main.java
@@ -1,0 +1,10 @@
+package org.honton.chas.exists.example;
+
+/**
+ * junk class to add to jar
+ */
+public class Main {
+  public static void main(String argv[]) {
+    System.out.println("OK.");
+  }
+}

--- a/src/it/fail/verify.bsh
+++ b/src/it/fail/verify.bsh
@@ -1,0 +1,24 @@
+import java.io.BufferedReader;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+  void findLine(BufferedReader reader, String expected) {
+    for(;;) {
+      String line = reader.readLine();
+      if(line == null) {
+        throw new IllegalStateException(expected + " not found");
+      }
+      if(line.matches(expected)) {
+        return;
+      }
+    }
+  }
+
+  File file = new File(basedir, "build.log" );
+  BufferedReader reader = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8);
+
+  findLine(reader, "\\[INFO\\] --- exists-maven-plugin:[0-9\\.]*:local \\(before-installation\\) @ exists-fail-it ---");
+  findLine(reader, "\\[INFO\\] setting maven.install.skip=false");
+  findLine(reader, "\\[INFO\\] --- exists-maven-plugin:[0-9\\.]*:local \\(after-installation\\) @ exists-fail-it ---");
+  findLine(reader, "\\[ERROR\\] Failed to execute goal org.honton.chas:exists-maven-plugin:[0-9\\.]*:local \\(after-installation\\) on project exists-fail-it: Artifact already exists in repository: org.honton.chas:exists-fail-it:[0-9\\.]*/exists-fail-it-[0-9\\.]*.jar -> \\[Help 1\\]");

--- a/src/it/install/clean.bsh
+++ b/src/it/install/clean.bsh
@@ -1,0 +1,17 @@
+import java.io.File;
+import java.io.FileFilter;
+
+FileFilter fileFilter = new FileFilter() {
+  public boolean accept(File file) {
+    if (file.isDirectory()) {
+      file.listFiles(fileFilter);
+    }
+    file.delete();
+    return false;
+  }
+};
+
+File file = new File(localRepositoryPath, "org/honton/chas");
+file.listFiles(fileFilter);
+
+return null;

--- a/src/it/pom.xml
+++ b/src/it/pom.xml
@@ -9,6 +9,7 @@
 
   <modules>
     <module>deploy</module>
+    <module>fail</module>
     <module>install</module>
   </modules>
 

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0"?>
 <settings>
+  <servers>
+    <server>
+      <id>with-auth</id>
+      <username>user1</username>
+      <password>password123</password>
+    </server>
+  </servers>
   <profiles>
     <profile>
       <id>it-repo</id>

--- a/src/main/java/org/honton/chas/exists/AbstractExistsMojo.java
+++ b/src/main/java/org/honton/chas/exists/AbstractExistsMojo.java
@@ -35,8 +35,8 @@ public abstract class AbstractExistsMojo extends AbstractMojo {
   private String artifact;
 
   /**
-   * Set whether checksum is used to compare artifacts,  The default is the <em>install</em>
-   * plugin's configuration to create checksums.
+   * Set whether checksum is used to compare artifacts.  The default is the <em>install</em>
+   * plugin's configuration to create checksums (property <em>createChecksum</em>).
    */
   @Parameter(defaultValue = "${createChecksum}")
   private boolean useChecksum;
@@ -49,7 +49,7 @@ public abstract class AbstractExistsMojo extends AbstractMojo {
 
   private static final Pattern GAV_PARSER = Pattern.compile("^([^:]*):([^:]*):([^:]*)$");
 
-  protected abstract InputStream getRemoteArtifactStream(String uri) throws IOException;
+  protected abstract InputStream getRemoteArtifactStream(String uri) throws IOException, MojoExecutionException;
 
   protected abstract String getRepositoryBase() throws MojoExecutionException;
 
@@ -86,7 +86,7 @@ public abstract class AbstractExistsMojo extends AbstractMojo {
     return project.endsWith("-SNAPSHOT");
   }
 
-  protected abstract Boolean checkArtifactExists(String uri) throws IOException;
+  protected abstract Boolean checkArtifactExists(String uri) throws IOException, MojoExecutionException;
 
   private Boolean verifyWithChecksum()
       throws IOException, MojoFailureException, NoSuchAlgorithmException, MojoExecutionException {

--- a/src/main/java/org/honton/chas/exists/LocalExistsMojo.java
+++ b/src/main/java/org/honton/chas/exists/LocalExistsMojo.java
@@ -1,10 +1,10 @@
 package org.honton.chas.exists;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
+import java.nio.file.Files;
 import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -46,8 +46,11 @@ public class LocalExistsMojo extends AbstractExistsMojo {
   }
 
   @Override
-  protected InputStream getRemoteArtifactStream(String uri) throws IOException {
+  protected byte[] getRemoteChecksum(String uri) throws MojoExecutionException, IOException {
     File file = new File(uri);
-    return file.isFile() ?new FileInputStream(file) :null;
+    if (!file.isFile()) {
+      return null;
+    }
+    return Files.readAllBytes(file.toPath());
   }
 }


### PR DESCRIPTION
Changed the `remote` Mojo to use the Maven Wagon infrastructure to check for the existence of artifacts. That way, settings like proxy and authentication can be applied by specifying a server ID.

Provided a setting to set the property as user property.

Provided a setting to fail the build if an artifact exists (or does not exist), see #1.