### PR TITLE
Use --release flag for correct cross-compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[8,)</version>
+                  <version>[1.8,)</version>
                 </requireJavaVersion>
                 <requireMavenVersion>
                   <version>[3.5,)</version>
@@ -375,6 +375,16 @@
   </reporting>
 
   <profiles>
+    <!-- make sure to release for Java 8 -->
+    <profile>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.release>8</maven.compiler.release>
+      </properties>
+    </profile>
+
     <!-- publish site to github,
     1. mvn [clean install] site
     2. mvn -P gh-pages pre-site


### PR DESCRIPTION
When using this plugin with Java 8 and setting `-Dexists.cmpChecksum=true`, the Maven process exists with the error

```
Caused by: org.apache.maven.plugin.PluginContainerException: An API incompatibility was encountered while executing org.honton.chas:exists-maven-plugin:0.1.0:remote: java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer;
[...]
Caused by: java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer;
    at org.honton.chas.exists.CheckSum.readStream (CheckSum.java:48)
    at org.honton.chas.exists.CheckSum.getChecksumBytes (CheckSum.java:30)
    at org.honton.chas.exists.CheckSum.getChecksum (CheckSum.java:37)
```

The cause is the same as in e.g. https://github.com/plasma-umass/doppio/issues/497

The fix is to use the `--release` flag, as explained in e.g. https://stackoverflow.com/questions/43102787/what-is-the-release-flag-in-the-java-9-compiler

As `--release` is only available from Java 9 on, I had to put the property in a profile