### PR TITLE
handle more wagon implementations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.honton.chas</groupId>
   <artifactId>exists-maven-plugin</artifactId>
-  <version>0.4.1</version>
+  <version>0.5.0</version>
   <packaging>maven-plugin</packaging>
 
   <name>Artifact Exists Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.honton.chas</groupId>
   <artifactId>exists-maven-plugin</artifactId>
-  <version>0.4.0</version>
+  <version>0.4.1</version>
   <packaging>maven-plugin</packaging>
 
   <name>Artifact Exists Maven Plugin</name>

--- a/src/main/java/org/honton/chas/exists/RemoteExistsMojo.java
+++ b/src/main/java/org/honton/chas/exists/RemoteExistsMojo.java
@@ -1,6 +1,7 @@
 package org.honton.chas.exists;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -231,15 +232,19 @@ public class RemoteExistsMojo extends AbstractExistsMojo
     }
 
     String getContent(String resourceName) throws Exception {
+      byte[] bytes;
       if (wagon instanceof StreamingWagon) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ((StreamingWagon) wagon).getToStream(resourceName, baos);
-        return new String(baos.toByteArray(), StandardCharsets.ISO_8859_1);
+        bytes = baos.toByteArray();
       } else {
-        Path tmpFile = Files.createTempFile("checksum", null);
-        wagon.get(resourceName, tmpFile.toFile());
-        return new String(Files.readAllBytes(tmpFile), StandardCharsets.ISO_8859_1);
+        Path tmpFilePath = Files.createTempFile("checksum", null);
+        File tmpFile = tmpFilePath.toFile();
+        tmpFile.deleteOnExit();
+        wagon.get(resourceName, tmpFile);
+        bytes = Files.readAllBytes(tmpFilePath);
       }
+      return new String(bytes, StandardCharsets.ISO_8859_1);
     }
 
     @Override


### PR DESCRIPTION
The current implementation assumes that each wagon implementation is a subclass of `StreamingWagon`. This isn't the case for instance for the `s3-wagon` (https://github.com/seahen/maven-s3-wagon). This pr introduces a graceful fallback to full content retrieval to handle such cases.