### PR TITLE
Allow overriding the classifier in case no main artifact exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,24 +35,25 @@ In the following table `p:` indicates the default constituent properties are pre
 `project.distributionManagement.` e.g. for artifact parameter, the full default is
 `${project.artifactId}-${project.version}.${project.packaging}`
 
-| Parameter          | Default                                             | Description                                                                             |
-|--------------------|-----------------------------------------------------|-----------------------------------------------------------------------------------------|
-| artifact           | p: ${artifactId}-${version}.${packaging}            | The artifact within the project to query                                                |
-| cmpChecksum        | false                                               | Compare checksums of artifacts                                                          |
-| failIfExists       | false                                               | Fail the build if the artifact already exists                                           |
-| failIfNotExists    | false                                               | Fail the build if the artifact does not exist                                           |
-| failIfNotMatch     | false                                               | Fail the build if the artifact exists and cmpChecksum is set and checksums do not match |
-| lastSnapshotTime   |                                                     | The property to set with the timestamp of the last snapshot install / deploy            |
-| project            | p: ${groupId}:${artifactId}:${packaging}:${version} | The project within the repository to query                                              |
-| property           | ${maven.deploy.skip} _or_ ${maven.install.skip}     | The property to receive the result of the query                                         |
-| repository         | dm: ${repository.url}                               | For remote goal, the repository to query for artifacts                                  |
-| requireGoal        |                                                     | Execute goal only if requireGoal value matches one of the maven command line goals      |
-| serverId           | dm: ${repository.id}                                | For remote goal, the server ID to use for authentication and proxy settings             |
-| skip               | false                                               | Skip executing the plugin                                                               |
-| skipIfSnapshot     | true                                                | Skip the query if the project ends with -SNAPSHOT                                       |
-| snapshotRepository | dm: ${snapshotRepository.url}                       | For remote goal, the repository to query for snapshot artifacts                         |
-| snapshotServerId   | dm: ${snapshotRepository.id}                        | For remote goal, the server ID to use for snapshot authentication and proxy settings    |
-| userProperty       | false                                               | If the property should be set as a user property, to be available in child projects     |
+| Parameter           | Default                                             | Description                                                                             |
+|---------------------|-----------------------------------------------------|-----------------------------------------------------------------------------------------|
+| artifact            | p: ${artifactId}-${version}.${packaging}            | The artifact within the project to query                                                |
+| cmpChecksum         | false                                               | Compare checksums of artifacts                                                          |
+| failIfExists        | false                                               | Fail the build if the artifact already exists                                           |
+| failIfNotExists     | false                                               | Fail the build if the artifact does not exist                                           |
+| failIfNotMatch      | false                                               | Fail the build if the artifact exists and cmpChecksum is set and checksums do not match |
+| lastSnapshotTime    |                                                     | The property to set with the timestamp of the last snapshot install / deploy            |
+| project             | p: ${groupId}:${artifactId}:${packaging}:${version} | The project within the repository to query                                              |
+| classifier          |                                                     | The classifier to use for checking the repository, e.g. 'tests'                         |
+| property            | ${maven.deploy.skip} _or_ ${maven.install.skip}     | The property to receive the result of the query                                         |
+| repository          | dm: ${repository.url}                               | For remote goal, the repository to query for artifacts                                  |
+| requireGoal         |                                                     | Execute goal only if requireGoal value matches one of the maven command line goals      |
+| serverId            | dm: ${repository.id}                                | For remote goal, the server ID to use for authentication and proxy settings             |
+| skip                | false                                               | Skip executing the plugin                                                               |
+| skipIfSnapshot      | true                                                | Skip the query if the project ends with -SNAPSHOT                                       |
+| snapshotRepository  | dm: ${snapshotRepository.url}                       | For remote goal, the repository to query for snapshot artifacts                         |
+| snapshotServerId    | dm: ${snapshotRepository.id}                        | For remote goal, the server ID to use for snapshot authentication and proxy settings    |
+| userProperty        | false                                               | If the property should be set as a user property, to be available in child projects     |
 
 ## Requirements
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,10 @@
       <name>Pascal</name>
       <url>https://github.com/pascalgn</url>
     </developer>
+    <developer>
+      <name>Tom Anderegg</name>
+      <url>https://github.com/tomandegg</url>
+    </developer>
   </developers>
 
   <prerequisites>

--- a/src/it/local/install-test-jar-only/pom.xml
+++ b/src/it/local/install-test-jar-only/pom.xml
@@ -1,41 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.honton.chas.exists.it</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>local</artifactId>
     <version>0.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>local</artifactId>
-  <packaging>pom</packaging>
-
-  <modules>
-    <module>fail</module>
-    <module>install</module>
-    <module>install-require-goal</module>
-    <module>install-snapshot</module>
-    <module>install-test-jar-only</module>
-  </modules>
+  <artifactId>exists-install-test-jar-only-it</artifactId>
 
   <build>
     <plugins>
-
       <plugin>
-        <artifactId>maven-install-plugin</artifactId>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
         <executions>
-          <!-- install in earlier than usual phase -->
           <execution>
             <goals>
-              <goal>install</goal>
+              <goal>test-jar</goal>
             </goals>
-            <phase>integration-test</phase>
           </execution>
         </executions>
+        <configuration>
+          <skipIfEmpty>true</skipIfEmpty>
+        </configuration>
       </plugin>
-
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <configuration>
+          <allowIncompleteProjects>true</allowIncompleteProjects>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.honton.chas</groupId>
         <artifactId>exists-maven-plugin</artifactId>
@@ -48,9 +47,9 @@
             <phase>pre-integration-test</phase>
             <configuration>
               <failIfExists>true</failIfExists>
+              <classifier>tests</classifier>
             </configuration>
           </execution>
-
           <execution>
             <id>after-installation</id>
             <goals>
@@ -59,13 +58,11 @@
             <phase>verify</phase>
             <configuration>
               <failIfNotExists>true</failIfNotExists>
+              <classifier>tests</classifier>
             </configuration>
           </execution>
         </executions>
       </plugin>
-
     </plugins>
-
   </build>
-
 </project>

--- a/src/it/local/install-test-jar-only/src/test/java/org/honton/chas/exists/example/BuildProperties.java
+++ b/src/it/local/install-test-jar-only/src/test/java/org/honton/chas/exists/example/BuildProperties.java
@@ -1,0 +1,37 @@
+package org.honton.chas.exists.example;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import org.junit.jupiter.api.Assertions;
+
+class BuildProperties {
+  String localRepository;
+  String groupId;
+  String artifactId;
+  String version;
+  String pluginVersion;
+
+  BuildProperties() throws IOException {
+    Properties properties = new Properties();
+    try (InputStream is = getClass().getResourceAsStream("/test.properties")) {
+      Assertions.assertNotNull(is);
+      properties.load(is);
+    }
+
+    localRepository = properties.getProperty("localRepository");
+    Assertions.assertNotNull(localRepository);
+
+    groupId = properties.getProperty("groupId");
+    Assertions.assertNotNull(groupId);
+
+    artifactId = properties.getProperty("artifactId");
+    Assertions.assertNotNull(artifactId);
+
+    version = properties.getProperty("version");
+    Assertions.assertNotNull(version);
+
+    pluginVersion = properties.getProperty("pluginVersion");
+    Assertions.assertNotNull(pluginVersion);
+  }
+}

--- a/src/it/local/install-test-jar-only/src/test/java/org/honton/chas/exists/example/CleanTest.java
+++ b/src/it/local/install-test-jar-only/src/test/java/org/honton/chas/exists/example/CleanTest.java
@@ -1,0 +1,31 @@
+package org.honton.chas.exists.example;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class CleanTest {
+  private BuildProperties buildProperties;
+
+  @Test
+  void clean() throws IOException {
+    buildProperties = new BuildProperties();
+    String groupPath = buildProperties.groupId.replace('.', '/');
+    Path repoDir =
+        Paths.get(buildProperties.localRepository, groupPath, buildProperties.artifactId);
+    if (Files.exists(repoDir)) {
+      try (Stream<Path> walk = Files.walk(repoDir)) {
+        walk.sorted(Comparator.reverseOrder()).forEach(this::deleteFile);
+      }
+    }
+  }
+
+  void deleteFile(Path path) {
+    Assertions.assertDoesNotThrow(() -> Files.delete(path));
+  }
+}

--- a/src/it/local/install-test-jar-only/src/test/resources/test.properties
+++ b/src/it/local/install-test-jar-only/src/test/resources/test.properties
@@ -1,0 +1,5 @@
+groupId = ${project.groupId}
+artifactId = ${project.artifactId}
+version = ${project.version}
+localRepository = ${settings.localRepository}
+pluginVersion = ${plugin.version}

--- a/src/it/local/install-test-jar-only/verify.bsh
+++ b/src/it/local/install-test-jar-only/verify.bsh
@@ -1,0 +1,3 @@
+import org.honton.chas.exists.Verify;
+
+new Verify(basedir, "local").checkBuildLog();

--- a/src/it/pom.xml
+++ b/src/it/pom.xml
@@ -76,7 +76,7 @@
 
         <plugin>
           <artifactId>maven-install-plugin</artifactId>
-          <version>3.0.0-M1</version>
+          <version>3.1.1</version>
         </plugin>
 
         <plugin>

--- a/src/it/remote/deploy-test-jar-only/pom.xml
+++ b/src/it/remote/deploy-test-jar-only/pom.xml
@@ -1,41 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.honton.chas.exists.it</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>remote</artifactId>
     <version>0.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>local</artifactId>
-  <packaging>pom</packaging>
-
-  <modules>
-    <module>fail</module>
-    <module>install</module>
-    <module>install-require-goal</module>
-    <module>install-snapshot</module>
-    <module>install-test-jar-only</module>
-  </modules>
+  <artifactId>exists-deploy-test-jar-only-it</artifactId>
 
   <build>
     <plugins>
-
       <plugin>
-        <artifactId>maven-install-plugin</artifactId>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
         <executions>
-          <!-- install in earlier than usual phase -->
+          <execution>
+            <id>default-jar</id>
+            <phase>none</phase>
+          </execution>
           <execution>
             <goals>
-              <goal>install</goal>
+              <goal>test-jar</goal>
             </goals>
-            <phase>integration-test</phase>
           </execution>
         </executions>
+        <configuration>
+          <skipIfEmpty>true</skipIfEmpty>
+        </configuration>
       </plugin>
-
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <configuration>
+          <allowIncompleteProjects>true</allowIncompleteProjects>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.honton.chas</groupId>
         <artifactId>exists-maven-plugin</artifactId>
@@ -43,29 +47,27 @@
           <execution>
             <id>before-installation</id>
             <goals>
-              <goal>local</goal>
+              <goal>remote</goal>
             </goals>
             <phase>pre-integration-test</phase>
             <configuration>
               <failIfExists>true</failIfExists>
+              <classifier>tests</classifier>
             </configuration>
           </execution>
-
           <execution>
             <id>after-installation</id>
             <goals>
-              <goal>local</goal>
+              <goal>remote</goal>
             </goals>
-            <phase>verify</phase>
+            <phase>integration-test</phase>
             <configuration>
               <failIfNotExists>true</failIfNotExists>
+              <classifier>tests</classifier>
             </configuration>
           </execution>
         </executions>
       </plugin>
-
     </plugins>
-
   </build>
-
 </project>

--- a/src/it/remote/deploy-test-jar-only/src/main/java/org/honton/chas/exists/example/WebServer.java
+++ b/src/it/remote/deploy-test-jar-only/src/main/java/org/honton/chas/exists/example/WebServer.java
@@ -1,0 +1,121 @@
+package org.honton.chas.exists.example;
+
+import fi.iki.elonen.NanoHTTPD;
+import fi.iki.elonen.NanoHTTPD.Response.Status;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
+public class WebServer extends NanoHTTPD {
+
+  private static final Logger LOG = Logger.getLogger(WebServer.class.getName());
+
+  private static final Map<String, String> TYPES = new HashMap<>();
+
+  static {
+    TYPES.put("jar", "application/java-archive");
+    TYPES.put("asc", "text/plain");
+    TYPES.put("pom", "text/xml");
+  }
+
+  private Map<String, byte[]> storage = new HashMap<>();
+
+  public WebServer(int port) throws IOException {
+    super(port);
+    LOG.fine("Server running on port " + port);
+    start(NanoHTTPD.SOCKET_READ_TIMEOUT, false);
+  }
+
+  public static void main(String[] args) throws IOException {
+    new WebServer(Integer.parseInt(args[0]));
+  }
+
+  byte[] getInput(IHTTPSession session) throws IOException {
+    int length = Integer.parseInt(getHeader(session, "Content-Length"));
+    byte[] content = new byte[length];
+    session.getInputStream().read(content);
+    return content;
+  }
+
+  private String getHeader(IHTTPSession session, String key) {
+    for (Map.Entry<String, String> header : session.getHeaders().entrySet()) {
+      if (header.getKey().equalsIgnoreCase(key)) {
+        return header.getValue();
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public Response serve(IHTTPSession session) {
+    LOG.fine(session.getMethod() + " " + session.getUri());
+    Response response = generateResponse(session);
+    LOG.fine("Response: " + response.getStatus());
+    return response;
+  }
+
+  private Response generateResponse(IHTTPSession session) {
+    String uri = session.getUri();
+    if (uri.startsWith("/auth")) {
+      String authorization = session.getHeaders().get("authorization");
+      if (authorization == null || !authorization.equals("Basic dXNlcjE6cGFzc3dvcmQxMjM=")) {
+        Response response = NanoHTTPD.newFixedLengthResponse(Status.UNAUTHORIZED, "", null);
+        response.addHeader("WWW-Authenticate", "Basic realm=\"Authentication needed\"");
+        return response;
+      }
+      uri = uri.substring("/auth".length());
+    } else if (uri.startsWith("/header-auth")) {
+      String authorization = session.getHeaders().get("job-token");
+      if (authorization == null) {
+        return NanoHTTPD.newFixedLengthResponse(Status.UNAUTHORIZED, "Need Job-Token", null);
+      }
+      uri = uri.substring("/header-auth".length());
+    }
+    String type = getType(uri);
+    switch (session.getMethod()) {
+      case HEAD:
+        {
+          if (!storage.containsKey(uri)) {
+            return NanoHTTPD.newFixedLengthResponse(Status.NOT_FOUND, type, null);
+          }
+          return NanoHTTPD.newFixedLengthResponse(Status.OK, type, null);
+        }
+      case GET:
+        {
+          byte[] file = storage.get(uri);
+          if (file == null) {
+            return NanoHTTPD.newFixedLengthResponse(Status.NOT_FOUND, type, uri);
+          }
+          return newFixedLengthResponse(
+              Status.OK, type, new ByteArrayInputStream(file), (long) file.length);
+        }
+      case PUT:
+        {
+          try {
+            storage.put(uri, getInput(session));
+            return NanoHTTPD.newFixedLengthResponse(Status.OK, "", uri);
+          } catch (IOException e) {
+            return NanoHTTPD.newFixedLengthResponse(
+                Status.INTERNAL_ERROR, "text/plain", e.getMessage());
+          }
+        }
+      default:
+        return NanoHTTPD.newFixedLengthResponse(
+            Status.NOT_IMPLEMENTED, "text/plain", session.getMethod() + " not supported");
+    }
+  }
+
+  private String getType(String uri) {
+    int dot = uri.lastIndexOf('.');
+    if (dot == -1) {
+      return "text/plain";
+    } else {
+      String suffix = uri.substring(dot + 1);
+      String type = TYPES.get(suffix);
+      return type != null ? type : "text/" + suffix;
+    }
+  }
+}

--- a/src/it/remote/deploy-test-jar-only/src/test/java/org/honton/chas/exists/example/Main.java
+++ b/src/it/remote/deploy-test-jar-only/src/test/java/org/honton/chas/exists/example/Main.java
@@ -1,0 +1,10 @@
+package org.honton.chas.exists.example;
+
+/** junk class to add to jar */
+public class Main {
+  public static void main(String argv[]) {
+    for (String arg : argv) {
+      System.out.println(arg);
+    }
+  }
+}

--- a/src/it/remote/deploy-test-jar-only/src/test/resources/test.properties
+++ b/src/it/remote/deploy-test-jar-only/src/test/resources/test.properties
@@ -1,0 +1,5 @@
+groupId = ${project.groupId}
+artifactId = ${project.artifactId}
+version = ${project.version}
+localRepository = ${settings.localRepository}
+pluginVersion = ${plugin.version}

--- a/src/it/remote/deploy-test-jar-only/verify.bsh
+++ b/src/it/remote/deploy-test-jar-only/verify.bsh
@@ -1,0 +1,3 @@
+import org.honton.chas.exists.Verify;
+
+new Verify(basedir, "remote").checkBuildLog();

--- a/src/it/remote/pom.xml
+++ b/src/it/remote/pom.xml
@@ -15,6 +15,7 @@
   <modules>
     <module>deploy</module>
     <module>deploy-snapshot</module>
+    <module>deploy-test-jar-only</module>
     <module>deploy-with-auth</module>
     <module>deploy-with-encrypted-auth</module>
     <module>deploy-with-header-auth</module>

--- a/src/main/java/org/honton/chas/exists/AbstractExistsMojo.java
+++ b/src/main/java/org/honton/chas/exists/AbstractExistsMojo.java
@@ -36,6 +36,10 @@ public abstract class AbstractExistsMojo extends AbstractMojo {
       defaultValue = "${project.groupId}:${project.artifactId}:${project.packaging}:${project.version}")
   private String project;
 
+  /** The classifier to use, e.g., 'tests'. Will be appended to the artifact name. Useful if there is no main artifact. */
+  @Parameter(property = "exists.classifier", defaultValue = "")
+  private String classifier;
+
   /** The build artifact of the project to compare. Defaults to the project's principal artifact. */
   @Parameter(
       property = "exists.artifact",
@@ -131,7 +135,7 @@ public abstract class AbstractExistsMojo extends AbstractMojo {
     }
 
     try {
-      gav = new GAV(project, mavenProject.getPackaging());
+      gav = new GAV(project, mavenProject.getPackaging(), classifier);
       boolean snapshot = isSnapshot();
       if (skipIfSnapshot && snapshot) {
         getLog().debug("skipping -SNAPSHOT");

--- a/src/main/java/org/honton/chas/exists/GAV.java
+++ b/src/main/java/org/honton/chas/exists/GAV.java
@@ -12,9 +12,10 @@ public class GAV {
   final String groupId;
   final String artifactId;
   final String type;
+  final String classifier;
   final String version;
 
-  GAV(String project, String packaging) throws MojoFailureException {
+  GAV(String project, String packaging, String configuredClassifier) throws MojoFailureException {
     Matcher matcher = GAV_PARSER.matcher(project);
     if (!matcher.matches()) {
       throw new MojoFailureException(
@@ -25,7 +26,12 @@ public class GAV {
     artifactId = matcher.group(2);
     String optional = matcher.group(3);
     type = optional != null ? optional.substring(0, optional.length() - 1) : packaging;
+    classifier = configuredClassifier;
     version = matcher.group(4);
+  }
+
+  GAV(String project, String packaging) throws MojoFailureException {
+    this(project, packaging, null);
   }
 
   // https://cwiki.apache.org/confluence/display/MAVEN/Remote+repository+layout
@@ -44,6 +50,6 @@ public class GAV {
 
   private String artifactFile(String version) {
     // ${artifactId}${platformId==null?'':'-'+platformId}-${version}${classifier==null?'':'-'+classifier}.${type}
-    return artifactId + '-' + version + '.' + type;
+    return artifactId + '-' + version + (classifier != null ? "-" + classifier : "") + '.' + type;
   }
 }

--- a/src/test/java/org/honton/chas/exists/Verify.java
+++ b/src/test/java/org/honton/chas/exists/Verify.java
@@ -124,7 +124,7 @@ public class Verify {
   }
 
   private String goalExecution(String executionId) {
-    return "[INFO]" + " --- " + getPlugin("exists") + " (" + executionId + ") @ " + gav.artifactId + " ---";
+    return "[INFO]" + " --- " + getPlugin("exists-maven-plugin") + " (" + executionId + ") @ " + gav.artifactId + " ---";
   }
 
   private String coordinates() {


### PR DESCRIPTION
fixes #39 
- I decided to try a simple solution first with an additional configuration element `<classifier>`
- Adding the classifier to `<project>` isn't straight-forward, as `${packaging}` currently is optional (even though it is not declared so in the README). So adding the classifier there as another optional element would need some logic to determine which optional group is present - doable, but I didn’t know if you’d like the ‘complexity’. Another option would be to add the classifier as a mandatory group, but that would be a breaking change.
- I first wanted to get your feedback about this solution or whether you’d rather go another route. If we stay with this, the logging in {{AbstractExistsMojo.java}} (line 200 et. al.) could be adapted to display the classifier in addition to just the {{project}}, but it would need some changes to common code, so I wanted to postpone this work until after your feedback, if at all, because the classifier is visible in the artifact location that is checked and logged, so it might not give much more insight, after all.
- I had to bump the version of `maven-install-plugin`for the integration test as without the rather new `<allowIncompleteProjects>true</allowIncompleteProjects>` option, I wasn’t able to make the new integration tests work.
