### PR TITLE
fix: getArtifactChecksum must not return the content of a File

### DIFF
--- a/src/main/java/org/honton/chas/exists/LocalExistsMojo.java
+++ b/src/main/java/org/honton/chas/exists/LocalExistsMojo.java
@@ -61,9 +61,6 @@ public class LocalExistsMojo extends AbstractExistsMojo {
   protected String getArtifactChecksum(String file) throws IOException, GeneralSecurityException {
     Path path = getPath(localRepository.getBasedir(), file);
     getLog().debug("checking for resource " + path);
-    if (path.toFile().canRead()) {
-      return Files.readString(path, StandardCharsets.ISO_8859_1);
-    }
     return new CheckSum().getChecksum(path);
   }
 }


### PR DESCRIPTION
this should is a fix for 
https://github.com/chonton/exists-maven-plugin/issues/52
