### PR TITLE
Include slash between repository and path in log (Fixes #51)

### DIFF
--- a/src/main/java/org/honton/chas/exists/RemoteExistsMojo.java
+++ b/src/main/java/org/honton/chas/exists/RemoteExistsMojo.java
@@ -145,7 +145,7 @@ public class RemoteExistsMojo extends AbstractExistsMojo implements Contextualiz
   @Override
   protected boolean checkArtifactExists(String path) throws Exception {
     String repositoryBase = getRepositoryBase();
-    getLog().info("Checking for artifact at " + repositoryBase + path);
+    getLog().info("Checking for artifact at " + repositoryBase + "/" + path);
     try (WagonHelper wagonHelper = new WagonHelper(repositoryBase)) {
       return wagonHelper.resourceExists(path);
     }


### PR DESCRIPTION
Fixes #51

While debugging why my artifact was not found led me on a search for the missing slash. Fixing the log line so the next person doesn't have to.

The `repositoryBase` variable has its trailing slash explicitly stripped while the path groupId has its dots converted to slashes so has no leading slashes.