### PR TITLE
Fixes #59: Use parsed "type" from project setting when determining GAV in order to allow overriding the main pom packaging.

### DIFF
--- a/src/main/java/org/honton/chas/exists/GAV.java
+++ b/src/main/java/org/honton/chas/exists/GAV.java
@@ -36,7 +36,7 @@ public class GAV {
     classifier = configuredClassifier;
     version = matcher.group(4);
 
-    extension = extension(packageExtensions, packaging);
+    extension = extension(packageExtensions, type);
   }
 
   // https://maven.apache.org/ref/3.9.3/maven-core/artifact-handlers.html

--- a/src/test/java/org/honton/chas/exists/GAVTest.java
+++ b/src/test/java/org/honton/chas/exists/GAVTest.java
@@ -1,7 +1,5 @@
 package org.honton.chas.exists;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import java.util.Map;
 import org.apache.maven.plugin.MojoFailureException;
 import org.junit.jupiter.api.Assertions;
@@ -14,6 +12,14 @@ class GAVTest {
     GAV gav = new GAV("groupId:artifactId:packaging:version", "packaging", "classifier", null);
     Assertions.assertEquals(
         "groupId/artifactId/version/artifactId-version-classifier.packaging",
+        gav.artifactLocation());
+  }
+
+  @Test
+  void artifactLocationTypeOverrides() throws MojoFailureException {
+    GAV gav = new GAV("groupId:artifactId:pom:version", "packaging", "classifier", null);
+    Assertions.assertEquals(
+        "groupId/artifactId/version/artifactId-version-classifier.pom",
         gav.artifactLocation());
   }
 


### PR DESCRIPTION
This makes sense to me, but maybe I'm misunderstanding something. Let me know if you need me to do anything else, and thank you for a helpful plugin!